### PR TITLE
Extract ingenerator environment helpers to helpers package

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -1,2 +1,4 @@
 source 'https://supermarket.chef.io'
 metadata
+
+cookbook 'ingenerator-helpers', github: 'ingenerator/chef-ingenerator-helpers', branch: '1.x'

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -13,36 +13,16 @@ module Ingenerator
           raise ArgumentError.new('The SSH port configured in node[\'ssh\'][\'host_port\'] must be an integer')
         end
 
-
-        if is_environment?(:localdev) || is_environment?(:buildslave)
+        if node.is_environment?(:localdev, :buildslave)
           22
         else
           node['ssh']['host_port']
         end
       end
 
-      # Test if this is the specified environment
-      def is_environment?(env)
-        node_environment === env.to_sym
-      end
-
-      # Test if this is not the specified environment
-      def not_environment?(env)
-        node_environment != env.to_sym
-      end
-
-      # Get the current node environment
-      def node_environment
-        if node['ingenerator'] && node['ingenerator']['node_environment']
-          node['ingenerator']['node_environment'].to_sym
-        else
-          :production
-        end
-      end
     end
   end
 end
 
 # Make the helpers available in all recipes
 Chef::Recipe.send(:include, Ingenerator::Base::Helpers)
-Chef::Node.send(:include, Ingenerator::Base::Helpers)

--- a/metadata.rb
+++ b/metadata.rb
@@ -15,5 +15,6 @@ end
 depends "apt"
 depends 'firewall', '~>2.5'
 depends "hostsfile"
+depends 'ingenerator-helpers', '~> 1.0'
 depends "swap"
 depends "timezone-ii"

--- a/spec/libaries/helpers_spec.rb
+++ b/spec/libaries/helpers_spec.rb
@@ -2,132 +2,56 @@ require 'spec_helper'
 require_relative '../../libraries/helpers.rb'
 
 describe Ingenerator::Base::Helpers do
-  let (:my_recipe) { Class.new { extend Ingenerator::Base::Helpers }}
+  let (:my_recipe) { Class.new { extend Ingenerator::Base::Helpers } }
+  let (:node)      { {} }
+
+  before (:example) do
+    allow(my_recipe).to receive(:node).and_return node
+  end
+
+  shared_examples 'it raises exception in any environment' do
+
+    it 'raises exception in development environments' do
+      allow(node).to receive(:'is_environment?').with(:localdev, :buildslave).and_return true
+      expect {
+        my_recipe.custom_ssh_port
+      }.to raise_exception(ArgumentError)
+    end
+
+    it 'raises exception in production environments' do
+      allow(node).to receive(:'is_environment?').with(:localdev, :buildslave).and_return false
+      expect {
+        my_recipe.custom_ssh_port
+      }.to raise_exception(ArgumentError)
+    end
+
+  end
 
   describe 'custom_ssh_port' do
-    it 'throws exception if no port is defined in node attributes' do
-      allow(my_recipe).to receive(:node).and_return({})
+    context 'if no port is defined in node attributes' do
+      let (:node) { {} }
 
-      expect {
-        my_recipe.custom_ssh_port
-      }.to raise_exception(ArgumentError)
+      include_examples 'it raises exception in any environment'
     end
 
-    it 'throws exception if defined port is not an integer' do
-      allow(my_recipe).to receive(:node).and_return({'ssh' => {'host_port' => 'ab824'}})
+    context 'if defined port is not an integer' do
+      let (:node) { {'ssh' => {'host_port' => 'ab823'}} }
 
-      expect {
-        my_recipe.custom_ssh_port
-      }.to raise_exception(ArgumentError)
+      include_examples 'it raises exception in any environment'
     end
 
-    it 'returns valid port defined in node attributes' do
-      allow(my_recipe).to receive(:node).and_return({'ssh' => {'host_port' => 9823}})
-      expect(my_recipe.custom_ssh_port).to eq(9823)
-    end
+    context 'if defined port is valid' do
+      let (:node) { {'ssh' => {'host_port' => 9823}} }
 
-    shared_examples 'it always uses port 22 in this environment' do | node_environment |
-
-      it 'throws exception if no port is defined in node attributes' do
-        allow(my_recipe).to receive(:node).and_return({})
-
-        expect {
-          my_recipe.custom_ssh_port
-        }.to raise_exception(ArgumentError)
+      it 'returns configured port number in production environments' do
+        allow(node).to receive(:'is_environment?').with(:localdev, :buildslave).and_return false
+        expect(my_recipe.custom_ssh_port).to eq(9823)
       end
 
-      it 'always returns port 22' do
-        allow(my_recipe).to receive(:node).and_return({
-          'ingenerator' => {'node_environment' => node_environment},
-          'ssh'         => {'host_port' => 9823}
-        })
-        expect(my_recipe.custom_ssh_port).to eq(22)
+      it 'always returns port 22 in development environments' do
+        allow(node).to receive(:'is_environment?').with(:localdev, :buildslave).and_return false
+        expect(my_recipe.custom_ssh_port).to eq(9823)
       end
-
-    end
-
-    context 'in localdev environment' do
-      include_examples 'it always uses port 22 in this environment', :localdev
-    end
-
-    context 'in buildslave environment' do
-      include_examples 'it always uses port 22 in this environment', :buildslave
-    end
-
-  end
-
-  shared_examples 'it handles the node_environment as expected' do | is_environment, not_environment |
-
-    describe 'node_environment' do
-      it "is :#{is_environment}" do
-        expect(my_recipe.node_environment).to be(is_environment)
-      end
-    end
-
-    describe 'is_environment?' do
-      it "matches :#{is_environment}" do
-        expect(my_recipe.is_environment?(is_environment)).to be(true)
-      end
-
-      it "matches '#{is_environment}'" do
-        expect(my_recipe.is_environment?("#{is_environment}")).to be(true)
-      end
-
-      it "does not match :#{not_environment}" do
-        expect(my_recipe.is_environment?(not_environment)).to be(false)
-      end
-
-      it "does not match '#{not_environment}'" do
-        expect(my_recipe.is_environment?("#{not_environment}")).to be(false)
-      end
-    end
-
-    describe 'not_environment?' do
-      it "matches :#{not_environment}" do
-        expect(my_recipe.not_environment?(not_environment)).to be(true)
-      end
-
-      it "matches '#{not_environment}'" do
-        expect(my_recipe.not_environment?("#{not_environment}")).to be(true)
-      end
-
-      it "does not match :#{is_environment}" do
-        expect(my_recipe.not_environment?(is_environment)).to be(false)
-      end
-
-      it "does not match '#{is_environment}'" do
-        expect(my_recipe.not_environment?("#{is_environment}")).to be(false)
-      end
-
     end
   end
-
-  context 'when no node_environment is configured' do
-    before(:each) do
-      allow(my_recipe).to receive(:node).and_return({})
-    end
-
-    include_examples 'it handles the node_environment as expected', :production, :localdev
-  end
-
-  context "when node_environment is configured as (string) 'buildslave'" do
-    before(:each) do
-      allow(my_recipe).to receive(:node).and_return({
-        'ingenerator' => {'node_environment' => 'buildslave'}
-      })
-    end
-
-    include_examples 'it handles the node_environment as expected', :buildslave, :production
-  end
-
-  context 'when node_environment is configured as (symbol) :localdev' do
-    before(:each) do
-      allow(my_recipe).to receive(:node).and_return({
-        'ingenerator' => {'node_environment' => :localdev}
-      })
-    end
-
-    include_examples 'it handles the node_environment as expected', :localdev, :production
-  end
-
 end


### PR DESCRIPTION
For easier reuse in other cookbooks without having to have all the
cookbooks depend on ingenerator-base
